### PR TITLE
README: Fixup dts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,8 +41,9 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 			status = "okay";
 			compatible = "riscv";
 			riscv,isa = "rv64ima";
-			mmu-type = "riscv,sv48";
+			mmu-type = "riscv,sv57";
 			cpu0_intc: interrupt-controller {
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
@@ -54,8 +55,9 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 			status = "okay";
 			compatible = "riscv";
 			riscv,isa = "rv64ima";
-			mmu-type = "riscv,sv48";
+			mmu-type = "riscv,sv57";
 			cpu1_intc: interrupt-controller {
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
@@ -67,8 +69,9 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 			status = "okay";
 			compatible = "riscv";
 			riscv,isa = "rv64ima";
-			mmu-type = "riscv,sv48";
+			mmu-type = "riscv,sv57";
 			cpu2_intc: interrupt-controller {
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
@@ -80,8 +83,9 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 			status = "okay";
 			compatible = "riscv";
 			riscv,isa = "rv64ima";
-			mmu-type = "riscv,sv48";
+			mmu-type = "riscv,sv57";
 			cpu3_intc: interrupt-controller {
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
@@ -110,8 +114,10 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 
 		intc: interrupt-controller@8000000 {
 			#address-cells = <0>;
-			#interrupt-cells = <2>;
+			#interrupt-cells = <1>;
 			compatible = "thead,c900-plic";
+			reg = <0x0 0x08000000 0x0 0x04000000>;
+			riscv,ndev = <80>;
 			interrupt-controller;
 			interrupts-extended = <
 				&cpu0_intc  0xffffffff &cpu0_intc  9
@@ -119,10 +125,6 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 				&cpu2_intc  0xffffffff &cpu2_intc  9
 				&cpu3_intc  0xffffffff &cpu3_intc  9
 				>;
-			reg = <0x0 0x08000000 0x0 0x04000000>;
-			reg-names = "control";
-			riscv,max-priority = <7>;
-			riscv,ndev = <80>;
 		};
 	};
 };

--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ The T-HEAD C9xx DTB provided to OpenSBI generic firmware will usually have
 	#address-cells = <2>;
 	#size-cells = <2>;
 
-	memory@0 {
+	memory@60000000 {
 		device_type = "memory";
 		reg = <0x0 0x60000000 0x1 0x00000000>;
 	};
@@ -143,7 +143,7 @@ set $dtb_addr     = $rootfs_addr  - 0x00100000
 set $zsb_addr     = $rootfs_addr  - 0x00008000
 set $dyninfo_addr = $rootfs_addr  - 0x40
 
-# Load rootfs & kernel
+# Load kernel
 restore zero_stage_boot.bin binary          $zsb_addr
 restore <preceding dts example>.dtb binary  $dtb_addr
 restore fw_dynamic.bin binary               $opensbi_addr


### PR DESCRIPTION
Fixup warning:

hello.dts:24.36-28.6: Warning (interrupt_provider):
/cpus/cpu@0/interrupt-controller: Missing #address-cells in interrupt
provider
hello.dts:37.36-41.6: Warning (interrupt_provider):
/cpus/cpu@1/interrupt-controller: Missing #address-cells in interrupt
provider
hello.dts:50.36-54.6: Warning (interrupt_provider):
/cpus/cpu@2/interrupt-controller: Missing #address-cells in interrupt
provider
hello.dts:63.36-67.6: Warning (interrupt_provider):
/cpus/cpu@3/interrupt-controller: Missing #address-cells in interrupt
provider

Remove unnecessary plic setting.