### PR TITLE
README: Add description of local-semihosting

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -173,7 +173,7 @@ set *0x18030000 = 0x7f
 
 = Run
 
-Start Jtag Server, then use gdb connect the Jtag Server.
+Start Jtag Server with local-semihosting mode(opensbi requirements), then use gdb connect the Jtag Server.
 
 ....
 riscv64-elf-gdb -ex "tar remote <Jtag Server ip:port>" -x <your soc gdbinit> -x <preceding cpu gdbinit> -ex "c"

--- a/README.adoc
+++ b/README.adoc
@@ -173,7 +173,13 @@ set *0x18030000 = 0x7f
 
 = Run
 
-Start Jtag Server with local-semihosting mode(opensbi requirements), then use gdb connect the Jtag Server.
+Start Jtag Server with local-semihosting mode(opensbi requirements).
+
+....
+DebugServerConsole -prereset -ls
+....
+
+Then use gdb connect the Jtag Server.
 
 ....
 riscv64-elf-gdb -ex "tar remote <Jtag Server ip:port>" -x <your soc gdbinit> -x <preceding cpu gdbinit> -ex "c"


### PR DESCRIPTION
The new opensbi defaults to using semihosting simulation as the serial output device, so it is necessary to start DebugServer using local-semihosting mode.