### PR TITLE
feature: Add boot flag for enable RV64XT32

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,6 +144,7 @@ set $rootfs_addr  = $opensbi_addr + 0x04000000
 set $dtb_addr     = $rootfs_addr  - 0x00100000
 set $zsb_addr     = $rootfs_addr  - 0x00008000
 set $dyninfo_addr = $rootfs_addr  - 0x40
+set $flag_addr    = $rootfs_addr  - 0x100
 
 # Load kernel
 restore zero_stage_boot.bin binary          $zsb_addr
@@ -158,6 +159,11 @@ set *(unsigned long *)($dyninfo_addr + 16) = $vmlinux_addr
 set *(unsigned long *)($dyninfo_addr + 24) = 1
 set *(unsigned long *)($dyninfo_addr + 32) = 0
 set *(unsigned long *)($dyninfo_addr + 40) = -1
+
+# Set boot flag for CPU functional setting
+# BIT[0]: Enable RV64XT32 by setting mxstatus.[63]=1
+# set *(unsigned int *)$flag_addr = 0x1
+set *(unsigned int *)$flag_addr = 0x0
 
 # Set all harts reset address
 set *0x18030010 = $zsb_addr

--- a/feature.c
+++ b/feature.c
@@ -1,6 +1,20 @@
 #include "riscv_asm.h"
 #include "riscv_encoding.h"
 
+#define FLAG_RV64XT32	0x1
+
+extern unsigned long _load_start;
+
+static inline void setup_boot_flag(void)
+{
+#if __riscv_xlen == 64
+	unsigned int boot_flag;
+	boot_flag = *(unsigned int *)(_load_start + 0x00008000 - 0x100);
+	if (boot_flag & FLAG_RV64XT32)
+		csr_write(CSR_MXSTATUS, csr_read(CSR_MXSTATUS) | (1ULL << 63));
+#endif
+}
+
 void setup_features(void)
 {
 	unsigned int i, cpu_type, cpu_ver;
@@ -129,4 +143,6 @@ void setup_features(void)
 	default:
 		while(1);
 	}
+
+	setup_boot_flag();
 }


### PR DESCRIPTION
Set boot flag for CPU functional setting
BIT[0]: Enable RV64XT32 by setting mxstatus.[63]=1