### PR TITLE
CPID: parse cpu feaures depending on the register index

### DIFF
--- a/feature.c
+++ b/feature.c
@@ -25,15 +25,19 @@ static inline void setup_boot_flag(void)
 
 void setup_features(void)
 {
-	unsigned int i, cpu_type, cpu_ver, cpu_tnmodel;
-	unsigned long version[8];
+	unsigned int i, idx, cpu_type = 0, cpu_ver = 0xFFFF, cpu_tnmodel = 0xFFFF;
+	volatile unsigned long version = 0;
 
-	for (i = 0; i < 8; i++)
-		version[i] = csr_read(CSR_MCPUID);
-
-	cpu_type	= (version[0] >> 18) & 0xf;
-	cpu_tnmodel	= (version[0] >> 14) & 0x1;
-	cpu_ver		= (version[1] >> 12) & 0xffff;
+	for (i = 8; i != 0; i--) {
+		version = csr_read(CSR_MCPUID);
+		idx = (version >> 28) & 0xf;
+		if (idx == 0) {
+			cpu_type = (version >> 18) & 0xf;
+			cpu_tnmodel = (version >> 14) & 0x1;
+		} else if (idx == 1) {
+			cpu_ver = (version >> 12) & 0xffff;
+		}
+	}
 
 	/*
 	 * Warning: CSR_MCCR2 contains an L2 cache latency setting,

--- a/feature.c
+++ b/feature.c
@@ -28,7 +28,7 @@ void setup_features(void)
 	unsigned int i, idx, cpu_type = 0, cpu_ver = 0xFFFF, cpu_tnmodel = 0xFFFF;
 	volatile unsigned long version = 0;
 
-	for (i = 8; i != 0; i--) {
+	for (i = 7; i != 0; i--) {
 		version = csr_read(CSR_MCPUID);
 		idx = (version >> 28) & 0xf;
 		if (idx == 0) {
@@ -36,6 +36,9 @@ void setup_features(void)
 			cpu_tnmodel = (version >> 14) & 0x1;
 		} else if (idx == 1) {
 			cpu_ver = (version >> 12) & 0xffff;
+		}
+		if (cpu_ver != 0xFFFF && cpu_tnmodel != 0xFFFF) {
+			break;
 		}
 	}
 


### PR DESCRIPTION
Since the read from CPID register may not always from index 0 to 6 at any time, it will lead to the error info for cpu_ver and cpu_type. This change adds the register index check before parsing.
Furthermore, the CPID spec defines 7 registers available while 2 of them are useful for zsb now, this change also minimize the register access for efficiency.

I have some basic manual test on FPGA platforms with print out after the parse. Here is the test code and results:

Code:
	printf("cpu %x %x %x\n", cpu_type, cpu_ver, cpu_tnmodel);
Results:
	FPGA  --> print out
	//C908V R1S0P12.  --> cpu 5 100c 0
	//R908FDV-CP-XT R0S0P15.  --> cpu 2 f 0
	//C920v3-CP-XT R3S1P5.  --> cpu 3 3045 0
	//C907FDVM-rv32 R0S1P0.  --> cpu 6 40 0
	//C907FDVM-rv64 R0S0P16.  --> cpu 6 10 0
	//C908X-CP-XT R0S0P9.  --> cpu 5 9 1

As this change affects all platforms that supported by zsb, more tests for coverage are necessary.