### PR TITLE
feat: Add support for CentaurV4 (version 4.0.0)

### DIFF
--- a/feature.c
+++ b/feature.c
@@ -176,6 +176,17 @@ void setup_features(void)
 			csr_write(CSR_MHCR, 0x17f);
 			csr_write(CSR_MXSTATUS, 0x638000);
 			csr_write(CSR_MHINT, 0x650c);
+		} else if (cpu_ver >= 0x4000 && cpu_ver <= 0x4fff) { //4.0.0~4.x.x CentaurV4
+			csr_write(CSR_MSMPR, 0x1);
+			csr_write(CSR_MCCR2, 0xe249000b);
+			csr_write(CSR_MXSTATUS, 0x438100);
+			csr_write(CSR_MHINT, 0x31ea32c);
+			csr_write(CSR_MHINT2, 0x180);
+			csr_write(CSR_MHCR, 0x11ff);
+			csr_write(CSR_MHINT4, 0x2080);
+#if __riscv_xlen == 64
+			csr_write(CSR_MENVCFG, 0x4000000000000000);
+#endif
 		} else {
 			while(1);
 		}

--- a/feature.c
+++ b/feature.c
@@ -176,14 +176,13 @@ void setup_features(void)
 			csr_write(CSR_MHCR, 0x17f);
 			csr_write(CSR_MXSTATUS, 0x638000);
 			csr_write(CSR_MHINT, 0x650c);
-		} else if (cpu_ver >= 0x4000 && cpu_ver <= 0x4fff) { //4.0.0~4.x.x CentaurV4
+		} else if (cpu_ver >= 0x4000 && cpu_ver <= 0x4fff) { //4.0.0~4.x.x
 			csr_write(CSR_MSMPR, 0x1);
-			csr_write(CSR_MCCR2, 0xe249000b);
-			csr_write(CSR_MXSTATUS, 0x438100);
+			csr_write(CSR_MCCR2, 0xe24a000a);
+			csr_write(CSR_MXSTATUS, 0xc0c38000);
 			csr_write(CSR_MHINT, 0x31ea32c);
 			csr_write(CSR_MHINT2, 0x180);
 			csr_write(CSR_MHCR, 0x11ff);
-			csr_write(CSR_MHINT4, 0x2080);
 #if __riscv_xlen == 64
 			csr_write(CSR_MENVCFG, 0x4000000000000000);
 #endif


### PR DESCRIPTION
Add case for CT_CENTAURV4 with version 4.0.0 (0x4000) to support the new CPU revision.

Configuration values based on similar high-performance cores (case 0x3 3.x.x and case 0x2):

- Add version range 0x4000~0x4fff for CentaurV4 in case 0x4
- Configure MSMPR, MCCR2, MXSTATUS, MHINT, MHINT2, MHCR, MHINT4
- Add MENVCFG configuration for 64-bit mode