### PR TITLE
ci: Fix tag push and release triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: ci-build
 
 on:
   push:
+    tags:
+      - '**'
+  release:
+    types: [published]
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
- Add tags filter to push event so pushing a tag triggers the workflow
- Add release: published event to trigger on GitHub Release publishing